### PR TITLE
Tidepool sync 2026-05-11

### DIFF
--- a/MixpanelService.xcodeproj/project.pbxproj
+++ b/MixpanelService.xcodeproj/project.pbxproj
@@ -493,7 +493,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -578,7 +578,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -681,7 +681,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -762,7 +762,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -849,7 +849,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -930,7 +930,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/MixpanelServiceKit/MixpanelService.swift
+++ b/MixpanelServiceKit/MixpanelService.swift
@@ -12,6 +12,8 @@ public final class MixpanelService: Service {
 
     public static let pluginIdentifier = "MixpanelService"
 
+    public var pluginIdentifier: String { MixpanelService.pluginIdentifier }
+
     public static let localizedTitle = LocalizedString("Mixpanel", comment: "The title of the Mixpanel service")
 
     public weak var serviceDelegate: ServiceDelegate?

--- a/MixpanelServiceKitUI/MixpanelService+UI.swift
+++ b/MixpanelServiceKitUI/MixpanelService+UI.swift
@@ -11,18 +11,18 @@ import LoopKitUI
 import MixpanelServiceKit
 import HealthKit
 
-extension MixpanelService: ServiceUI {
+extension MixpanelService: @retroactive ServiceUI {
     
     public static var image: UIImage? {
         UIImage(named: "mixpanel_logo", in: Bundle(for: MixpanelServiceTableViewController.self), compatibleWith: nil)!
     }
 
-    public static func setupViewController(colorPalette: LoopUIColorPalette, pluginHost: PluginHost) -> SetupUIResult<ServiceViewController, ServiceUI>
+    public static func setupViewController(colorPalette: LoopUIColorPalette, pluginHost: PluginHost, allowDebugFeatures: Bool) -> SetupUIResult<ServiceViewController, ServiceUI>
     {
         return .userInteractionRequired(ServiceNavigationController(rootViewController: MixpanelServiceTableViewController(service: MixpanelService(), for: .create)))
     }
     
-    public func settingsViewController(colorPalette: LoopUIColorPalette) -> ServiceViewController
+    public func settingsViewController(colorPalette: LoopUIColorPalette, allowDebugFeatures: Bool) -> ServiceViewController
     {
         return ServiceNavigationController(rootViewController: MixpanelServiceTableViewController(service: self, for: .update))
     }


### PR DESCRIPTION
Refreshed Tidepool → DIY sync from the `tidepool-sync/2026-05-11` branch.

This supersedes and replaces the previous Tidepool Merge PR (#4), which is being closed in favor of this one.